### PR TITLE
Socket error box: per-socket help links + fix double-https href

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -58,7 +58,7 @@ class App extends Component {
 
   render () {
     if (this.state.error) {
-      return <Error>{this.state.error}</Error>
+      return <Error mode={this.props.config.mode}>{this.state.error}</Error>
     } else if (this.props.config.mode === 'enquiry') {
       return <PlainEnquiry root={this} config={this.props.config}/>
     } else if (this.props.config.mode === 'enquiry-modal') {

--- a/src/components/shared/Error.js
+++ b/src/components/shared/Error.js
@@ -1,17 +1,26 @@
 import React from 'react'
 
-const HELP_SITE = 'https://help.tutorcruncher.com/en/articles/8255881-getting-started-with-tutorcruncher-socket'
+const DEFAULT_HELP_URL = 'https://help.tutorcruncher.com/en/articles/8255881-getting-started-with-tutorcruncher-socket'
 
-const Error = ({children}) => (
-  <div className="tcs-errors">
-    <p>An error occurred while loading TutorCruncher socket:</p>
-    <p className="tcs-error-content">{children}</p>
-    <p>
-      It's likely that you've configured socket wrongly. You might get more information from the developer console,
-      or <a target="_blank" rel="noopener noreferrer" href={'https://' + HELP_SITE}>{HELP_SITE}</a>,
-      if you still can't work out what's wrong contact support@tutorcruncher.com.
-    </p>
-  </div>
-)
+const HELP_URLS = {
+  appointments: 'https://help.tutorcruncher.com/en/articles/14182713-online-lesson-booking-socket',
+}
+
+export const help_url = mode => HELP_URLS[mode] || DEFAULT_HELP_URL
+
+const Error = ({children, mode}) => {
+  const help = help_url(mode)
+  return (
+    <div className="tcs-errors">
+      <p>An error occurred while loading TutorCruncher socket:</p>
+      <p className="tcs-error-content">{children}</p>
+      <p>
+        It's likely that you've configured socket wrongly. You might get more information from the developer console,
+        or <a target="_blank" rel="noopener noreferrer" href={help}>{help}</a>,
+        if you still can't work out what's wrong contact support@tutorcruncher.com.
+      </p>
+    </div>
+  )
+}
 
 export default Error

--- a/src/tests/AppError.test.js
+++ b/src/tests/AppError.test.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import {MemoryRouter} from 'react-router-dom'
+import App from '../components/App'
+
+jest.mock('marked', () => ({setOptions: () => null}))
+
+const config = {
+  mode: 'appointments',
+  router_mode: 'history',
+  event_callback: () => null,
+}
+
+it('error render uses appointments help link', () => {
+  window.ga = () => null
+  const wrapper = enz.mount(
+    <MemoryRouter>
+      <App error="boom" config={config} url_generator={u => u}/>
+    </MemoryRouter>
+  )
+  const link = wrapper.find('a')
+  expect(link.prop('href')).toBe('https://help.tutorcruncher.com/en/articles/14182713-online-lesson-booking-socket')
+  expect(wrapper.find('.tcs-error-content').text()).toBe('boom')
+})

--- a/src/tests/Error.test.js
+++ b/src/tests/Error.test.js
@@ -1,0 +1,54 @@
+import React from 'react'
+import Error from '../components/shared/Error'
+
+const APPOINTMENTS_URL = 'https://help.tutorcruncher.com/en/articles/14182713-online-lesson-booking-socket'
+const DEFAULT_URL = 'https://help.tutorcruncher.com/en/articles/8255881-getting-started-with-tutorcruncher-socket'
+
+it('links to the lesson-booking article for appointments mode', () => {
+  const wrapper = enz.shallow(<Error mode="appointments">whatever</Error>)
+  const link = wrapper.find('a')
+  expect(link.prop('href')).toBe(APPOINTMENTS_URL)
+  expect(link.text()).toBe(APPOINTMENTS_URL)
+})
+
+it('links to the generic article for grid mode', () => {
+  const wrapper = enz.shallow(<Error mode="grid">whatever</Error>)
+  const link = wrapper.find('a')
+  expect(link.prop('href')).toBe(DEFAULT_URL)
+  expect(link.text()).toBe(DEFAULT_URL)
+})
+
+it('links to the generic article for list mode', () => {
+  const wrapper = enz.shallow(<Error mode="list">whatever</Error>)
+  expect(wrapper.find('a').prop('href')).toBe(DEFAULT_URL)
+})
+
+it('links to the generic article for enquiry mode', () => {
+  const wrapper = enz.shallow(<Error mode="enquiry">whatever</Error>)
+  expect(wrapper.find('a').prop('href')).toBe(DEFAULT_URL)
+})
+
+it('links to the generic article for an unknown mode', () => {
+  const wrapper = enz.shallow(<Error mode="nonsense">whatever</Error>)
+  expect(wrapper.find('a').prop('href')).toBe(DEFAULT_URL)
+})
+
+it('links to the generic article when mode is undefined (back-compat)', () => {
+  const wrapper = enz.shallow(<Error>whatever</Error>)
+  expect(wrapper.find('a').prop('href')).toBe(DEFAULT_URL)
+})
+
+it('builds a clean https url with no double protocol', () => {
+  const wrapper = enz.shallow(<Error mode="appointments">whatever</Error>)
+  const href = wrapper.find('a').prop('href')
+  expect(href).not.toMatch(/https:\/\/https:\/\//)
+  expect(href.match(/https:\/\//g).length).toBe(1)
+})
+
+it('preserves target, rel and children', () => {
+  const wrapper = enz.shallow(<Error mode="grid">boom</Error>)
+  const link = wrapper.find('a')
+  expect(link.prop('target')).toBe('_blank')
+  expect(link.prop('rel')).toBe('noopener noreferrer')
+  expect(wrapper.find('.tcs-error-content').text()).toBe('boom')
+})


### PR DESCRIPTION
**Issue number: tutorcruncher/TutorCruncher2#16780**

(Cross-repo issue. GitHub does not auto-close issues across repos, so this references rather than closes it.)

### Technical description of changes

The socket error box rendered a single hard-coded help-article link for every socket type. The link is now selected by the active socket `mode`: a small `mode -> URL` map plus an exported `help_url()` helper returns the lesson-booking article for the `appointments` socket and falls back to the existing generic getting-started article for the other modes. This also fixes a real bug where the link's `href` was built by concatenating `'https://'` onto a URL that already started with `https://`, producing a broken `https://https://...` link. The URL is now a single source of truth used for both the `href` and the visible text.

### Description for the non-dev team to understand

When a TutorCruncher Socket fails to load, the error message offers a "more information" help link. Until now that link always pointed at the same general getting-started article no matter which kind of socket was on the page, and the link itself was broken (it had `https://` twice, so it did not open). Now the lesson-booking socket sends customers straight to the lesson-booking help article and the link works correctly. The other socket types keep using the general article for now, until we have their specific help pages.

#### Supporting Screenshots

The demo below renders the actual `Error` component output (its exact markup, the real `.tcs-errors` styles, and the `help_url()` values from this PR), shown Before (current production) next to After (this PR) as the socket type changes. It is a faithful render of the component rather than the full webpack build: the widget's 2019-era toolchain (`node-sass@4` / `react-scripts@3`) cannot build on this machine (arm64 / Node 26). Netlify builds it fine in its own Linux env.

**Before:**
Every socket shows the same generic getting-started article, and the link is broken (the `href` has `https://` twice, so it 404s). This is the left column in the demo.

**After:**
The `appointments` (lesson-booking) socket links to the online-lesson-booking-socket article; other modes fall back to the generic article; the `href` is a single valid URL. This is the right column in the demo.

**Demo (GIF):**

<img src="https://github.com/tutorcruncher/socket-frontend/raw/pr-screenshots/socket-error-help-link-16780.gif" width="900">

<sub>Full-quality video: https://github.com/tutorcruncher/socket-frontend/raw/pr-screenshots/socket-error-help-link-16780.webm</sub>

#### Recreation Steps
1. Embed a TutorCruncher Socket configured as a lesson-booking (`appointments`) socket with an invalid key so it errors.
2. Look at the "more information" link in the error box.
   - Before: points at the generic getting-started article, and the href is malformed (`https://https://...`).
   - After: points at the `online-lesson-booking-socket` help article with a valid single-`https://` URL.

### Manual testing required
- Trigger the socket error box for an `appointments` socket: confirm the help link is the lesson-booking article and opens correctly.
- Trigger it for a grid/list/enquiry socket: confirm it still shows the generic article.

### Notes for reviewers
- Only the lesson-booking (`appointments`) help URL was provided in the issue. The other socket modes intentionally fall back to the generic article until the client supplies their specific articles, so this is easy to extend (one line per mode in `HELP_URLS`).
- This repo has no CI (only a Netlify build), so there is no CircleCI/coverage gate. Verified locally: `CI=true yarn test src/tests/Error.test.js src/tests/AppError.test.js` -> 9/9 pass; `yarn lint` -> exit 0. `Error.js` is 100% covered and the changed `App.js` line is covered.
- Pre-existing and out of scope: `src/tests/App.test.js` and `src/tests/index.test.js` fail to run on modern Node with `_marked.default.setOptions is not a function` (a `marked@4` CJS interop issue originating in `src/utils.js`, on the production markdown/webpack path). This is unrelated to this change and deliberately not touched.

### Checklist

* [x] Issue number added
* [x] Tests
* [ ] Help docs written and links added <-- To be done with the support team.
* [x] Coverage
* [x] Correct labels applied
* [x] Doc Strings Clear
* [x] Type casting
* [ ] Dev Guide Updated

### Public desc (for support team to populate)
@@
The socket error message now links to the help article for that specific socket type (starting with the lesson-booking socket), and the previously broken help link is fixed.
@@
